### PR TITLE
Provide a bid on every assertion, even suspicious & unknown ones

### DIFF
--- a/src/microenginewebhookspy/models.py
+++ b/src/microenginewebhookspy/models.py
@@ -2,8 +2,13 @@ import dataclasses
 import enum
 import requests
 
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, Optional
 from polyswarmartifact.schema import Verdict as ScanMetadata
+
+
+class Phase(enum.Enum):
+    ASSERTION = 'assertion'
+    ARBITRATION = 'arbitration'
 
 
 class Verdict(enum.Enum):
@@ -16,7 +21,7 @@ class Verdict(enum.Enum):
 @dataclasses.dataclass
 class Assertion:
     verdict: str
-    bid: Optional[int]
+    bid: int
     metadata: Dict
 
     def __eq__(self, other):

--- a/src/microenginewebhookspy/scan.py
+++ b/src/microenginewebhookspy/scan.py
@@ -31,10 +31,6 @@ def compute_bid(bounty: Bounty, scan_result: ScanResult) -> int:
     max_bid = bounty.rules.get(settings.MAX_BID_RULE_NAME, settings.DEFAULT_MAX_BID)
     min_bid = bounty.rules.get(settings.MIN_BID_RULE_NAME, settings.DEFAULT_MIN_BID)
 
-    if scan_result.verdict in [Verdict.UNKNOWN, Verdict.SUSPICIOUS]:
-        # These results will produce no bill. Just set the field to be accepted
-        return 0
-
     bid = min_bid + max(scan_result.confidence * (max_bid - min_bid), 0)
     bid = min(bid, max_bid)
     return bid

--- a/src/microenginewebhookspy/tasks.py
+++ b/src/microenginewebhookspy/tasks.py
@@ -1,6 +1,6 @@
 from celery import Celery
 
-from microenginewebhookspy.models import Bounty, ScanResult, Verdict, Assertion
+from microenginewebhookspy.models import Bounty, ScanResult, Verdict, Assertion, Phase
 from microenginewebhookspy import settings
 from microenginewebhookspy.scan import scan, compute_bid
 
@@ -11,6 +11,11 @@ celery_app = Celery('tasks', broker=settings.BROKER)
 def handle_bounty(bounty):
     bounty = Bounty(**bounty)
     scan_result = scan(bounty)
-    bid = compute_bid(bounty, scan_result)
+
+    if bounty.phase == Phase.ARBITRATION or scan_result.verdict in [Verdict.UNKNOWN, Verdict.SUSPICIOUS]:
+        # These results don't bid any NCT.
+        bid = 0
+    else:
+        bid = compute_bid(bounty, scan_result)
 
     bounty.post_assertion(scan_result.to_assertion(bid))


### PR DESCRIPTION
Suspicious & Unknown are not biddable. Just setting the bid to 0 to have it accepted as the field is required there.

Also add a test for URL bounties: should be answered as "unknown"