### PR TITLE
Fix selectors in charts for service and hpa

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -51,6 +51,22 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Nginx Selector labels
+*/}}
+{{- define "microengine-webhooks-py.nginx.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "microengine-webhooks-py.name" . }}-nginx
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Worker Selector labels
+*/}}
+{{- define "microengine-webhooks-py.worker.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "microengine-webhooks-py.name" . }}-worker
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "microengine-webhooks-py.serviceAccountName" -}}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -51,7 +51,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Nginx Selector labels
+Nginx labels
+*/}}
+{{- define "microengine-webhooks-py.nginx.labels" -}}
+helm.sh/chart: {{ include "microengine-webhooks-py.chart" . }}
+{{ include "microengine-webhooks-py.nginx.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Nginx selector labels
 */}}
 {{- define "microengine-webhooks-py.nginx.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "microengine-webhooks-py.name" . }}-nginx
@@ -59,7 +71,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Worker Selector labels
+Worker labels
+*/}}
+{{- define "microengine-webhooks-py.worker.labels" -}}
+helm.sh/chart: {{ include "microengine-webhooks-py.chart" . }}
+{{ include "microengine-webhooks-py.worker.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Worker selector labels
 */}}
 {{- define "microengine-webhooks-py.worker.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "microengine-webhooks-py.name" . }}-worker

--- a/chart/templates/nginx.deployment.yaml
+++ b/chart/templates/nginx.deployment.yaml
@@ -10,7 +10,7 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-      {{- include "microengine-webhooks-py.selectorLabels" . | nindent 6 }}
+      {{- include "microengine-webhooks-py.nginx.selectorLabels" . | nindent 6 }}
   template:
     metadata:
     {{- with .Values.nginx.podAnnotations }}
@@ -18,7 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
-        {{- include "microengine-webhooks-py.selectorLabels" . | nindent 8 }}
+        {{- include "microengine-webhooks-py.nginx.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.nginx.imagePullSecrets }}
       imagePullSecrets:

--- a/chart/templates/nginx.deployment.yaml
+++ b/chart/templates/nginx.deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "microengine-webhooks-py.fullname" . }}-nginx
   labels:
-    {{- include "microengine-webhooks-py.labels" . | nindent 4 }}
+    {{- include "microengine-webhooks-py.nginx.labels" . | nindent 4 }}
 spec:
 {{- if not .Values.nginx.autoscaling.enabled }}
   replicas: {{ .Values.nginx.replicaCount }}

--- a/chart/templates/nginx.hpa.yaml
+++ b/chart/templates/nginx.hpa.yaml
@@ -4,7 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "microengine-webhooks-py.fullname" . }}-nginx
   labels:
-    {{- include "microengine-webhooks-py.labels" . | nindent 4 }}
+    {{- include "microengine-webhooks-py.nginx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/chart/templates/nginx.hpa.yaml
+++ b/chart/templates/nginx.hpa.yaml
@@ -9,7 +9,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "microengine-webhooks-py.fullname" . }}
+    name: {{ include "microengine-webhooks-py.fullname" . }}-nginx
   minReplicas: {{ .Values.nginx.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.nginx.autoscaling.maxReplicas }}
   metrics:

--- a/chart/templates/nginx.ingress.yaml
+++ b/chart/templates/nginx.ingress.yaml
@@ -10,7 +10,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}-nginx
   labels:
-    {{- include "microengine-webhooks-py.labels" . | nindent 4 }}
+    {{- include "microengine-webhooks-py.nginx.labels" . | nindent 4 }}
   {{- with .Values.nginx.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/chart/templates/nginx.service.yaml
+++ b/chart/templates/nginx.service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ include "microengine-webhooks-py.fullname" . }}-nginx
   labels:
-    {{- include "microengine-webhooks-py.labels" . | nindent 4 }}
+    {{- include "microengine-webhooks-py.nginx.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.nginx.service.type }}
   ports:

--- a/chart/templates/nginx.service.yaml
+++ b/chart/templates/nginx.service.yaml
@@ -12,4 +12,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "microengine-webhooks-py.selectorLabels" . | nindent 4 }}
+    {{- include "microengine-webhooks-py.nginx.selectorLabels" . | nindent 4 }}

--- a/chart/templates/worker.deployment.yaml
+++ b/chart/templates/worker.deployment.yaml
@@ -34,6 +34,8 @@ spec:
           image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
           env:
+          - name: PYTHONUNBUFFERED
+            value: "1"
           - name: CELERY_BROKER_URL
             valueFrom:
               secretKeyRef:

--- a/chart/templates/worker.deployment.yaml
+++ b/chart/templates/worker.deployment.yaml
@@ -10,7 +10,7 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-      {{- include "microengine-webhooks-py.selectorLabels" . | nindent 6 }}
+      {{- include "microengine-webhooks-py.worker.selectorLabels" . | nindent 6 }}
   template:
     metadata:
     {{- with .Values.worker.podAnnotations }}
@@ -18,7 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
-        {{- include "microengine-webhooks-py.selectorLabels" . | nindent 8 }}
+        {{- include "microengine-webhooks-py.worker.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.worker.imagePullSecrets }}
       imagePullSecrets:

--- a/chart/templates/worker.deployment.yaml
+++ b/chart/templates/worker.deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "microengine-webhooks-py.fullname" . }}-worker
   labels:
-    {{- include "microengine-webhooks-py.labels" . | nindent 4 }}
+    {{- include "microengine-webhooks-py.worker.labels" . | nindent 4 }}
 spec:
 {{- if not .Values.worker.autoscaling.enabled }}
   replicas: {{ .Values.worker.replicaCount }}

--- a/chart/templates/worker.hpa.yaml
+++ b/chart/templates/worker.hpa.yaml
@@ -4,7 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "microengine-webhooks-py.fullname" . }}-worker
   labels:
-    {{- include "microengine-webhooks-py.labels" . | nindent 4 }}
+    {{- include "microengine-webhooks-py.worker.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/chart/templates/worker.hpa.yaml
+++ b/chart/templates/worker.hpa.yaml
@@ -9,7 +9,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "microengine-webhooks-py.fullname" . }}
+    name: {{ include "microengine-webhooks-py.fullname" . }}-worker
   minReplicas: {{ .Values.worker.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.worker.autoscaling.maxReplicas }}
   metrics:


### PR DESCRIPTION
Fixes the hpa targets to point to the correct pods. 

Fixes the service selector labels to point to the correct pods. 