### PR TITLE
Simplify installing requirements in nginx image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /usr/src/app
 COPY requirements.txt .
 
 RUN apt update && apt install -y python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
     && pip3 install --no-cache-dir -r requirements.txt
 
 COPY setup.py .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,10 +7,7 @@ WORKDIR /usr/src/app
 COPY requirements.txt .
 
 RUN apt update && apt install -y python3-pip \
-    && pip3 install --no-cache-dir -r requirements.txt \
-    && apt remove -y python3-pip \
-    && apt autoremove --purge -y \
-    && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/*.list
+    && pip3 install --no-cache-dir -r requirements.txt
 
 COPY setup.py .
 COPY src .

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ python-dateutil~=2.8.1
 python-json-logger~=2.0.1
 requests~=2.22.0
 requests-mock~=1.8.0
-six~=1.15.0 # required for python-dateutil in nginx/unit:1.19.0-python3.7


### PR DESCRIPTION
These deletions cause some issue with packages. 

Removing the deletions should fix issues when using web3 in an Engine