### PR TITLE
Add optional datadog metrics

### DIFF
--- a/chart/secrets.yaml
+++ b/chart/secrets.yaml
@@ -1,3 +1,5 @@
 global:
   celeryBrokerUrl: ""
   webhookSecret: ""
+  datadogApiKey: ""
+  datadogAppKey: ""

--- a/chart/templates/shared.secret.yaml
+++ b/chart/templates/shared.secret.yaml
@@ -11,3 +11,5 @@ type: Opaque
 data:
   CELERY_BROKER_URL: {{ required "need celery broker url" .Values.global.celeryBrokerUrl | b64enc | quote }}
   WEBHOOK_SECRET: {{ required "need webhook secret" .Values.global.webhookSecret | b64enc | quote }}
+  DATADOG_API_KEY: {{ .Values.global.datadogApiKey | b64enc | quote }}
+  DATADOG_APP_KEY: {{ .Values.global.datadogAppKey | b64enc | quote }}

--- a/chart/templates/worker.deployment.yaml
+++ b/chart/templates/worker.deployment.yaml
@@ -49,12 +49,12 @@ spec:
           - name: DATADOG_API_KEY
             valueFrom:
               secretKeyRef:
-                name: { { template "microengine-kaspersky.fullname" . } }
+                name: {{ template "microengine-kaspersky.fullname" . }}
                 key: DATADOG_API_KEY
           - name: DATADOG_APP_KEY
             valueFrom:
               secretKeyRef:
-                name: { { template "microengine-kaspersky.fullname" . } }
+                name: {{ template "microengine-kaspersky.fullname" . }}
                 key: DATADOG_APP_KEY
           - name: LOG_LEVEL
             value: {{ .Values.worker.logLevel }}

--- a/chart/templates/worker.deployment.yaml
+++ b/chart/templates/worker.deployment.yaml
@@ -49,12 +49,12 @@ spec:
           - name: DATADOG_API_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ template "microengine-kaspersky.fullname" . }}
+                name: {{ template "microengine-webhooks-py.fullname" . }}
                 key: DATADOG_API_KEY
           - name: DATADOG_APP_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ template "microengine-kaspersky.fullname" . }}
+                name: {{ template "microengine-webhooks-py.fullname" . }}
                 key: DATADOG_APP_KEY
           - name: LOG_LEVEL
             value: {{ .Values.worker.logLevel }}

--- a/chart/templates/worker.deployment.yaml
+++ b/chart/templates/worker.deployment.yaml
@@ -46,6 +46,16 @@ spec:
               secretKeyRef:
                 name: {{ template "microengine-webhooks-py.fullname" . }}
                 key: WEBHOOK_SECRET
+          - name: DATADOG_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: { { template "microengine-kaspersky.fullname" . } }
+                key: DATADOG_API_KEY
+          - name: DATADOG_APP_KEY
+            valueFrom:
+              secretKeyRef:
+                name: { { template "microengine-kaspersky.fullname" . } }
+                key: DATADOG_APP_KEY
           - name: LOG_LEVEL
             value: {{ .Values.worker.logLevel }}
           - name: LOG_FORMAT

--- a/chart/templates/worker.deployment.yaml
+++ b/chart/templates/worker.deployment.yaml
@@ -62,6 +62,8 @@ spec:
             value: {{ .Values.worker.logFormat }}
           - name: PROCESS_TYPE
             value: {{ .Values.worker.processType }}
+          - name: POLY_WORK
+            value: {{ .Values.worker.polyWork }}
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
       {{- with .Values.worker.nodeSelector }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -18,6 +18,7 @@ worker:
   logLevel: "WARNING"
   logFormat: "json"
   processType: "celery"
+  polyWork: "local"
 
   replicaCount: 1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask~=1.1.2
 bump2version
 celery~=4.4.7
+microengine-utils~=1.5.0
 polyswarm-artifact~=1.4.3
 pytest~=5.4.2
 pytest-cov~=2.10.1

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     install_requires=[
         "celery",
         "Flask",
+        "microengine-utils",
         "polyswarm-artifact",
         "requests",
         "python-json-logger"

--- a/src/microenginewebhookspy/settings.py
+++ b/src/microenginewebhookspy/settings.py
@@ -13,6 +13,12 @@ MIN_BID_RULE_NAME = os.environ.get('MIN_BID_RULE_NAME', 'min_allowed_bid')
 DEFAULT_MAX_BID = os.environ.get('DEFAULT_MAX_BID', to_wei(1))
 DEFAULT_MIN_BID = os.environ.get('DEFAULT_MIN_BID', to_wei(1) / 16)
 
+# Metrics values
+DATADOG_API_KEY = os.environ.get('DATADOG_API_KEY')
+DATADOG_APP_KEY = os.environ.get('DATADOG_APP_KEY')
+ENGINE_NAME = os.environ.get('ENGINE_NAME', 'kaspersky')
+POLY_WORK = os.environ.get('POLY_WORK', 'local')
+
 
 class JSONFormatter(jsonlogger.JsonFormatter):
     """

--- a/src/microenginewebhookspy/settings.py
+++ b/src/microenginewebhookspy/settings.py
@@ -16,7 +16,7 @@ DEFAULT_MIN_BID = os.environ.get('DEFAULT_MIN_BID', to_wei(1) / 16)
 # Metrics values
 DATADOG_API_KEY = os.environ.get('DATADOG_API_KEY')
 DATADOG_APP_KEY = os.environ.get('DATADOG_APP_KEY')
-ENGINE_NAME = os.environ.get('ENGINE_NAME', 'kaspersky')
+ENGINE_NAME = os.environ.get('ENGINE_NAME', 'microengine-webhooks-py')
 POLY_WORK = os.environ.get('POLY_WORK', 'local')
 
 

--- a/src/microenginewebhookspy/tasks.py
+++ b/src/microenginewebhookspy/tasks.py
@@ -34,7 +34,8 @@ def handle_bounty(bounty):
         try:
             scan_result = scan(bounty)
             handle_bounty.metrics.increment(SCAN_SUCCESS, tags=[f'type:{bounty.artifact_type}'])
-            handle_bounty.metrics.increment(SCAN_VERDICT, tags=[f'type:{bounty.artifact_type}', f'verdict:{scan_result.verdict.value}'])
+            handle_bounty.metrics.increment(SCAN_VERDICT, tags=[f'type:{bounty.artifact_type}',
+                                                                f'verdict:{scan_result.verdict.value}'])
         except errors.HighCompressionScanError:
             handle_bounty.metrics.increment(
                 SCAN_FAIL, tags=[bounty.artifact_type, 'scan_error: High Compression']

--- a/src/microenginewebhookspy/tasks.py
+++ b/src/microenginewebhookspy/tasks.py
@@ -1,16 +1,68 @@
-from celery import Celery
+from celery import Celery, Task
+from microengine_utils import errors
+from microengine_utils.datadog import configure_metrics
+from microengine_utils.constants import SCAN_FAIL, SCAN_SUCCESS, SCAN_TIME, SCAN_VERDICT
 
 from microenginewebhookspy.models import Bounty, ScanResult, Verdict, Assertion, Phase
 from microenginewebhookspy import settings
 from microenginewebhookspy.scan import scan, compute_bid
 
+
 celery_app = Celery('tasks', broker=settings.BROKER)
 
 
-@celery_app.task
+class MetricsTask(Task):
+    _metrics = None
+
+    @property
+    def metrics(self):
+        if self._metrics is None:
+            self._metrics = configure_metrics(
+                settings.DATADOG_API_KEY,
+                settings.DATADOG_APP_KEY,
+                settings.ENGINE_NAME,
+                poly_work=settings.POLY_WORK
+            )
+
+        return self._metrics
+
+
+@celery_app.task(base=MetricsTask)
 def handle_bounty(bounty):
     bounty = Bounty(**bounty)
-    scan_result = scan(bounty)
+    with handle_bounty.metrics.timer(SCAN_TIME):
+        try:
+            scan_result = scan(bounty)
+            handle_bounty.metrics.increment(SCAN_SUCCESS, tags=[bounty.artifact_type])
+            handle_bounty.metrics.increment(SCAN_VERDICT, tags=[bounty.artifact_type, scan_result.verdict.value])
+        except errors.HighCompressionScanError:
+            handle_bounty.metrics.increment(
+                SCAN_FAIL, tags=[bounty.artifact_type, 'scan_error: High Compression']
+            )
+        except errors.EncryptedFileScanError:
+            handle_bounty.metrics.increment(
+                SCAN_FAIL, tags=[bounty.artifact_type, 'scan_error: File encrypted']
+            )
+        except errors.CorruptFileScanError:
+            handle_bounty.metrics.increment(
+                SCAN_FAIL, tags=[bounty.artifact_type, 'scan_error: File corrupted']
+            )
+        except errors.FileSkippedScanError:
+            handle_bounty.metrics.increment(
+                SCAN_FAIL, tags=[bounty.artifact_type, 'scan_error: File Skipped']
+            )
+        except errors.ServerNotReadyScanError:
+            handle_bounty.metrics.increment(
+                SCAN_FAIL, tags=[bounty.artifact_type, 'scan_error: Server not ready']
+            )
+        except errors.CalledProcessScanError:
+            handle_bounty.metrics.increment(
+                SCAN_FAIL, tags=[bounty.artifact_type, 'scan_error: Error running scan process']
+            )
+        except errors.UnprocessableScanError:
+            handle_bounty.metrics.increment(
+                SCAN_FAIL, tags=[bounty.artifact_type, 'scan_error: Unprocessable']
+            )
 
     if bounty.phase == Phase.ARBITRATION:
         scan_response = scan_result.to_vote()

--- a/src/microenginewebhookspy/tasks.py
+++ b/src/microenginewebhookspy/tasks.py
@@ -33,8 +33,8 @@ def handle_bounty(bounty):
     with handle_bounty.metrics.timer(SCAN_TIME):
         try:
             scan_result = scan(bounty)
-            handle_bounty.metrics.increment(SCAN_SUCCESS, tags=[bounty.artifact_type])
-            handle_bounty.metrics.increment(SCAN_VERDICT, tags=[bounty.artifact_type, scan_result.verdict.value])
+            handle_bounty.metrics.increment(SCAN_SUCCESS, tags=[f'type:{bounty.artifact_type}'])
+            handle_bounty.metrics.increment(SCAN_VERDICT, tags=[f'type:{bounty.artifact_type}', f'verdict:{scan_result.verdict.value}'])
         except errors.HighCompressionScanError:
             handle_bounty.metrics.increment(
                 SCAN_FAIL, tags=[bounty.artifact_type, 'scan_error: High Compression']


### PR DESCRIPTION
Adds metrics collection with datadog by default. 

Does not report anything to PolySwarm, only Datadog.

Only reports metrics to datadog if both `DATADOG_APP_KEY` and `DATADOG_API_KEY` are set.

Collects: 

1. scan time
1. count of successful scans
1. verdicts
1. errors