### PR TITLE
Assign default ScanResult value

### DIFF
--- a/src/microenginewebhookspy/tasks.py
+++ b/src/microenginewebhookspy/tasks.py
@@ -30,6 +30,7 @@ class MetricsTask(Task):
 @celery_app.task(base=MetricsTask)
 def handle_bounty(bounty):
     bounty = Bounty(**bounty)
+    scan_result = ScanResult()
     with handle_bounty.metrics.timer(SCAN_TIME):
         try:
             scan_result = scan(bounty)


### PR DESCRIPTION
We added metrics collection on the microengine-utils errors, but except to still return a ScanResult where `verdict==Verdict.UNKNOWN` even in error cases. 

This adds that default value.