### PR TITLE
[FIX] Always send bids as `int`

### DIFF
--- a/src/microenginewebhookspy/scan.py
+++ b/src/microenginewebhookspy/scan.py
@@ -27,4 +27,4 @@ def compute_bid(bounty: Bounty, scan_result: ScanResult) -> int:
 
     bid = min_bid + max(scan_result.confidence * (max_bid - min_bid), 0)
     bid = min(bid, max_bid)
-    return bid
+    return int(bid)

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -2,6 +2,9 @@ import hmac
 import os
 import random
 import requests
+from logging import getLogger
+
+logger = getLogger(__name__)
 
 from flask import Flask, request, jsonify
 
@@ -25,7 +28,14 @@ empty_digest = hmac.new(WEBHOOK_SECRET.encode('utf-8'), b'', digestmod='sha256')
 
 @application.route("/", methods=['POST'])
 def test_receiver():
-    body = request.get_json()
+    breakpoint()
+    try:
+        body = request.get_json()
+    except Exception as err:
+        if 'Failed to decode JSON' not in str(err):
+            # Do not swallow unknown errors
+            raise
+        body = request.get_data()
     print(body)
     return jsonify("OK"), 200
 

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -2,9 +2,6 @@ import hmac
 import os
 import random
 import requests
-from logging import getLogger
-
-logger = getLogger(__name__)
 
 from flask import Flask, request, jsonify
 

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -25,7 +25,6 @@ empty_digest = hmac.new(WEBHOOK_SECRET.encode('utf-8'), b'', digestmod='sha256')
 
 @application.route("/", methods=['POST'])
 def test_receiver():
-    breakpoint()
     try:
         body = request.get_json()
     except Exception as err:


### PR DESCRIPTION
Bids should always be sent as `int`, not `float`, regardless of any precision loss on conversion.

_(CI is broken right now. Will be fixed Soon™)_