### PR TITLE
[FIX] Bounty ignore extra fields 

### DIFF
--- a/src/microenginewebhookspy/models.py
+++ b/src/microenginewebhookspy/models.py
@@ -3,6 +3,7 @@ import logging
 import dataclasses
 import enum
 import requests
+import functools
 
 from typing import Dict, Any, Optional, Union
 from polyswarmartifact.schema import ScanMetadata
@@ -14,6 +15,7 @@ logger = logging.getLogger(__name__)
 def ignore_extra_fields(cls):
     class_init = cls.__init__
 
+    @functools.wraps(class_init)
     def new_init(self, *args, **kwargs):
         fields = {f.name for f in dataclasses.fields(cls)}
         new_kwargs = {k: v for k, v in kwargs.items() if k in fields}

--- a/src/microenginewebhookspy/models.py
+++ b/src/microenginewebhookspy/models.py
@@ -11,6 +11,18 @@ from polyswarmartifact.schema import ScanMetadata
 logger = logging.getLogger(__name__)
 
 
+def ignore_extra_fields(cls):
+    class_init = cls.__init__
+
+    def new_init(self, *args, **kwargs):
+        fields = {f.name for f in dataclasses.fields(cls)}
+        new_kwargs = {k: v for k, v in kwargs.items() if k in fields}
+        class_init(self, *args, **new_kwargs)
+
+    cls.__init__ = new_init
+    return cls
+
+
 class Phase(enum.Enum):
     ASSERTION = 'assertion'
     ARBITRATION = 'arbitration'
@@ -49,6 +61,7 @@ class ScanResult:
         return Vote(self.verdict.value, self.metadata.dict())
 
 
+@ignore_extra_fields
 @dataclasses.dataclass(frozen=True)
 class Bounty:
     id: int

--- a/src/microenginewebhookspy/models.py
+++ b/src/microenginewebhookspy/models.py
@@ -61,6 +61,8 @@ class Bounty:
     mimetype: Optional[str] = None
     phase: Optional[str] = None
     metadata: Optional[dict] = None
+    duration: Optional[str] = None
+    tasked_at: Optional[str] = None
 
     def fetch_artifact(self):
         session = requests.Session()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -37,7 +37,9 @@ def test_valid_bounty_to_api(requests_mock):
                     expiration=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     phase='assertion_window',
                     response_url=response_url,
-                    rules={}
+                    rules={},
+                    duration=30,
+                    extra_spam='extra eggs',
                     )
     headers = {'X-POLYSWARM-EVENT': 'bounty'}
     response = client.post('/', headers=headers, json=dataclasses.asdict(bounty))


### PR DESCRIPTION
By ignoring extra fields on Bounty instantiation, we can smooth the upgrade of schemas.